### PR TITLE
トーストコンポーネント

### DIFF
--- a/src/components/Toast/Toast.stories.ts
+++ b/src/components/Toast/Toast.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Toast from '@/components/Toast/Toast';
+
+const meta = {
+  title: 'Components/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} as Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Copied: Story = {
+  args: {
+    message: 'Copied!',
+    isShow: true,
+  },
+};

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -11,7 +11,7 @@ const Toast = ({ message, isShow }: Props) => {
   return (
     <div
       className={clsx(
-        'rounded-xl bg-[#28d186] px-28 py-3 text-2xl text-white opacity-80',
+        'rounded-xl bg-black px-28 py-3 text-2xl text-white opacity-80',
         `${isShow ? 'block' : 'hidden'}`,
       )}
     >

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import clsx from 'clsx';
+
+type Props = {
+  message: string;
+  isShow: boolean;
+};
+
+const Toast = ({ message, isShow }: Props) => {
+  return (
+    <div
+      className={clsx(
+        'rounded-xl bg-[#28d186] px-28 py-3 text-2xl text-white opacity-80',
+        `${isShow ? 'block' : 'hidden'}`,
+      )}
+    >
+      {message}
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## 対応したIssue

{Issue番号}を、自分の対応したIssue番号に変更してね！
Closes #52 

## やったこと
- トーストコンポーネントの実装
- 表示するメッセージと表示フラグを親から渡せるように
  - 表示非表示の切り替えは親側で行う想定です

## やってないこと
- このコンポーネントを実装するにあたっては、画面のどこに表示するかまでは考えてないです

## 確認方法
- storybookでお願いします
  - もしまだclsx入れてからパッケージ更新していない方は'$ npm ci'お願いします

## その他
デザインと見た目変えてますmm
デザイン通りの方が良かった、ほかの方がUI的に優れているなどあれば教えてください！
背景色とか文字色を親から渡せるようにするのも無しではないと思ってます！が、何でもありになっちゃうのでこれはこれで考えものかも？