### PR TITLE
feat: TextLinkコンポーネントの実装

### DIFF
--- a/src/components/TextLink/TextLink.stories.ts
+++ b/src/components/TextLink/TextLink.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TextLink from '@/components/TextLink/TextLink';
+
+const meta = {
+  title: 'Components/TextLink',
+  component: TextLink,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} as Meta<typeof TextLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Spring: Story = {
+  args: {
+    children: '診断START',
+    href: '',
+    target: '_blank',
+  },
+};

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+type Props = {
+  children: string;
+  href: string;
+  target: '_blank' | '_self' | '_top' | '_parent';
+};
+
+const TextLink = ({ children, href, target = '_blank' }: Props) => {
+  return (
+    <Link
+      className="min-w-48 rounded-xl bg-primary px-8 py-3 text-center text-2xl font-bold text-black shadow-primary hover:opacity-80 disabled:opacity-50"
+      href={href}
+      target={target}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default TextLink;


### PR DESCRIPTION
## 対応したIssue

{Issue番号}を、自分の対応したIssue番号に変更してね！
Closes #33 

## やったこと
- テキストリンクコンポーネントの実装

## やってないこと

## 確認方法
- storybookでお願いしますー！

## その他
ボタンとリンクの使い分けのためのコンポーネントなので、テキストボタンと見た目は同じです