### PR TITLE
シェアリンクで共有するリンクを修正

### DIFF
--- a/src/components/ResultTemplate/ResultTemplate.tsx
+++ b/src/components/ResultTemplate/ResultTemplate.tsx
@@ -11,7 +11,7 @@ import { snsImagePaths } from '@/constants/snsImagePaths';
 import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type Props = {
   result: 'spring' | 'summer' | 'autumn' | 'winter';
@@ -59,8 +59,12 @@ const ResultTemplate = ({ result }: Props) => {
   const imagePaths = resultImagePaths[result];
   const resultTexts = resultText[result];
   const [isShow, setIsShow] = useState(false);
+  const [pageUrl, setPageUrl] = useState('');
 
-  const pageUrl = window.location.href;
+  useEffect(() => {
+    setPageUrl(window.location.href);
+  }, [pageUrl]);
+
   const SNS_ITEM_LIST = [
     {
       key: 'line',

--- a/src/components/ResultTemplate/ResultTemplate.tsx
+++ b/src/components/ResultTemplate/ResultTemplate.tsx
@@ -56,11 +56,12 @@ const BG_COLOR = {
 } as const;
 
 // todo: シェアリンクのgoogle.com部分を結果ページのリンクに置き換える
+const pageUrl = window.location.href;
 const SNS_ITEM_LIST = [
   {
     key: 'line',
     // https://social-plugins.line.me/lineit/share?url=google.com$text=任意のテキストを埋め込める
-    shareLink: `https://social-plugins.line.me/lineit/share?url=google.com`,
+    shareLink: `https://social-plugins.line.me/lineit/share?url=${pageUrl}`,
     ...snsImagePaths.line,
   },
   {
@@ -71,12 +72,12 @@ const SNS_ITEM_LIST = [
   {
     key: 'x',
     // https://twitter.com/intent/tweet?url=google.com&text=ポストさせたい任意のテキストを埋め込める
-    shareLink: `https://twitter.com/intent/tweet?url=google.com`,
+    shareLink: `https://twitter.com/intent/tweet?url=${pageUrl}`,
     ...snsImagePaths.x,
   },
   {
     key: 'facebook',
-    shareLink: `https://www.facebook.com/share.php?u=google.com`,
+    shareLink: `https://www.facebook.com/share.php?u=${pageUrl}`,
     ...snsImagePaths.facebook,
   },
 ] as const;

--- a/src/components/ResultTemplate/ResultTemplate.tsx
+++ b/src/components/ResultTemplate/ResultTemplate.tsx
@@ -55,38 +55,36 @@ const BG_COLOR = {
   winter: '#BCD3DF',
 } as const;
 
-// todo: シェアリンクのgoogle.com部分を結果ページのリンクに置き換える
-const pageUrl = window.location.href;
-const SNS_ITEM_LIST = [
-  {
-    key: 'line',
-    // https://social-plugins.line.me/lineit/share?url=google.com$text=任意のテキストを埋め込める
-    shareLink: `https://social-plugins.line.me/lineit/share?url=${pageUrl}`,
-    ...snsImagePaths.line,
-  },
-  {
-    key: 'insta',
-    shareLink: ``,
-    ...snsImagePaths.insta,
-  },
-  {
-    key: 'x',
-    // https://twitter.com/intent/tweet?url=google.com&text=ポストさせたい任意のテキストを埋め込める
-    shareLink: `https://twitter.com/intent/tweet?url=${pageUrl}`,
-    ...snsImagePaths.x,
-  },
-  {
-    key: 'facebook',
-    shareLink: `https://www.facebook.com/share.php?u=${pageUrl}`,
-    ...snsImagePaths.facebook,
-  },
-] as const;
-
 const ResultTemplate = ({ result }: Props) => {
   const imagePaths = resultImagePaths[result];
   const resultTexts = resultText[result];
   const [isShow, setIsShow] = useState(false);
 
+  const pageUrl = window.location.href;
+  const SNS_ITEM_LIST = [
+    {
+      key: 'line',
+      // https://social-plugins.line.me/lineit/share?url=google.com$text=任意のテキストを埋め込める
+      shareLink: `https://social-plugins.line.me/lineit/share?url=${pageUrl}`,
+      ...snsImagePaths.line,
+    },
+    {
+      key: 'insta',
+      shareLink: ``,
+      ...snsImagePaths.insta,
+    },
+    {
+      key: 'x',
+      // https://twitter.com/intent/tweet?url=google.com&text=ポストさせたい任意のテキストを埋め込める
+      shareLink: `https://twitter.com/intent/tweet?url=${pageUrl}`,
+      ...snsImagePaths.x,
+    },
+    {
+      key: 'facebook',
+      shareLink: `https://www.facebook.com/share.php?u=${pageUrl}`,
+      ...snsImagePaths.facebook,
+    },
+  ] as const;
   const copyToClipboard = () => {
     navigator.clipboard.writeText(window.location.href);
     setIsShow(true);


### PR DESCRIPTION
## 対応したIssue

{Issue番号}を、自分の対応したIssue番号に変更してね！
Closes #65 

## やったこと
- SNSで共有する際、ページのリンクを動的に取れるように

## やってないこと
- 共有時のメッセージについては別タスクに切り出した

## 確認方法
実際のページで確認してもらった方がいいかもです！
Previewとかからみるとはやいかも？